### PR TITLE
Fix some confusion with lightguns, minor touchups with makefile and cinterface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 CXXFLAGS := -I. -I./apu/bapu \
 	-fpermissive \
 	-std=c++0x \
+	-Wno-delete-abstract-non-virtual-dtor -Wno-misleading-indentation \
+	-Wno-user-defined-warnings -Wno-empty-body -Wno-unused -Wno-deprecated \
+	-Wno-int-to-pointer-cast -Wno-unsequenced -Wno-bitwise-op-parentheses \
 	-D__WIN32_LIBSNES__ -DNDEBUG \
 	-DHAVE_STRINGS_H -DHAVE_STDINT_H -DRIGHTSHIFT_IS_SAR -D__LIBRETRO__ -DSNES_JOY_READ_CALLBACKS
 


### PR DESCRIPTION
The hackery to make relative values for lightguns did more harm than good, as BizHawk sends in absolute values anyways (and since they aren't negative ever, it made the cursor locked in the bottom right corner). BizHawk sends in relative values for the mouse, so the hackery should be correct there (I think?). Also, a button for an offscreen shot is placed in last, I have c# changes which make use of this, but otherwise it acts like a no-op without those changes.