### PR TITLE
ensure resampler buffer size spans at least 20ms

### DIFF
--- a/apu/apu.cpp
+++ b/apu/apu.cpp
@@ -184,7 +184,7 @@ bool8 S9xInitSound(int buffer_ms)
 {
     // The resampler and spc unit use samples (16-bit short) as arguments.
     int buffer_size_samples = MINIMUM_BUFFER_SIZE;
-    int requested_buffer_size_samples = Settings.SoundPlaybackRate * buffer_ms * 2 / 1000;
+    int requested_buffer_size_samples = Settings.SoundInputRate * buffer_ms * 2 / 1000;
 
     if (requested_buffer_size_samples > buffer_size_samples)
         buffer_size_samples = requested_buffer_size_samples;

--- a/bizhawk/cinterface.cpp
+++ b/bizhawk/cinterface.cpp
@@ -354,7 +354,7 @@ ECL_EXPORT int biz_init()
 		return 0;
 	}
 
-	S9xInitSound(0); // 16, 0)
+	S9xInitSound(21);
 	S9xSetSoundMute(FALSE);
 	//S9xSetSamplesAvailableCallback(S9xAudioCallback, NULL);
 


### PR DESCRIPTION
- closes https://github.com/TASEmulators/BizHawk/issues/4194.

The original code confusingly used output rate to calculate buffer size so I've changed that as well. Note that 20ms without leeway will drop some samples in pal (50 fps) games so 21 should be safe.